### PR TITLE
Update the dotnet sync action

### DIFF
--- a/.github/workflows/ReportDiff.ps1
+++ b/.github/workflows/ReportDiff.ps1
@@ -29,7 +29,7 @@ $issue = $issue + '/comments'
 $result = Invoke-RestMethod -Method POST -Headers $Headers -Uri $issue -Body $json
 
 # Make a branch
-$timestamp = get-date -format "yyyy-MMM-dd-HH:mm:ss"
+$timestamp = get-date -format "yyyy-MMM-dd-HH-mm-ss"
 $branch = "github-action/sync-dotnet-extensions-" + $timestamp
 cd azure-extensions
 git checkout -b $branch

--- a/.github/workflows/ReportDiff.ps1
+++ b/.github/workflows/ReportDiff.ps1
@@ -31,6 +31,7 @@ $result = Invoke-RestMethod -Method POST -Headers $Headers -Uri $issue -Body $js
 # Make a branch
 $timestamp = get-date -format "yyyy-MMM-dd-HH:mm:ss"
 $branch = "github-action/sync-dotnet-extensions-" + $timestamp
+cd azure-extensions
 git checkout -b $branch
 
 # Check if there's an open PR in Azure or Dotnet orgs to resolve this difference.

--- a/.github/workflows/ReportDiff.ps1
+++ b/.github/workflows/ReportDiff.ps1
@@ -39,8 +39,7 @@ $sendpr = $true
 $Headers = @{ Accept = 'application/vnd.github.v3+json'; Authorization = 'token {0}' -f $ENV:GITHUB_TOKEN; };
 
 # Test this script using changes in a fork
-# $prsLink = "https://api.github.com/repos/azure/dotnet-extensions-experimental/pulls?state=open"
-$prsLink = "https://api.github.com/repos/tratcher/dotnet-extensions-experimental/pulls?state=open"
+$prsLink = "https://api.github.com/repos/azure/dotnet-extensions-experimental/pulls?state=open"
 $result = Invoke-RestMethod -Method GET -Headers $Headers -Uri $prsLink
 
 foreach ($pr in $result) {

--- a/.github/workflows/ReportDiff.ps1
+++ b/.github/workflows/ReportDiff.ps1
@@ -1,6 +1,7 @@
 # Check the code is in sync
 $changed = (select-string "nothing to commit" artifacts\status.txt).count -eq 0
 if (-not $changed) { return $changed }
+
 # Check if tracking issue is open/closed
 $Headers = @{ Authorization = 'token {0}' -f $ENV:GITHUB_TOKEN; };
 $result = Invoke-RestMethod -Uri $issue -Headers $Headers
@@ -27,12 +28,18 @@ $json = ConvertTo-Json -InputObject @{ 'body' = $body }
 $issue = $issue + '/comments'
 $result = Invoke-RestMethod -Method POST -Headers $Headers -Uri $issue -Body $json
 
+# Make a branch
+$timestamp = get-date -format "yyyy-MMM-dd-HH:mm:ss"
+$branch = "github-action/sync-dotnet-extensions-" + $timestamp
+git checkout -b $branch
+
 # Check if there's an open PR in Azure or Dotnet orgs to resolve this difference.
 $sendpr = $true
 $Headers = @{ Accept = 'application/vnd.github.v3+json'; Authorization = 'token {0}' -f $ENV:GITHUB_TOKEN; };
 
 # Test this script using changes in a fork
-$prsLink = "https://api.github.com/repos/azure/dotnet-extensions-experimental/pulls?state=open"
+# $prsLink = "https://api.github.com/repos/azure/dotnet-extensions-experimental/pulls?state=open"
+$prsLink = "https://api.github.com/repos/tratcher/dotnet-extensions-experimental/pulls?state=open"
 $result = Invoke-RestMethod -Method GET -Headers $Headers -Uri $prsLink
 
 foreach ($pr in $result) {

--- a/.github/workflows/dotnet-sync.yml
+++ b/.github/workflows/dotnet-sync.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   compare_repos:
     # Comment out this line to test the scripts in a fork
-    # if: github.repository == 'azure/dotnet-extensions-experimental'
+    if: github.repository == 'azure/dotnet-extensions-experimental'
     name: Sync shared code between Azure and DotNet
     runs-on: windows-latest
     steps:
@@ -24,8 +24,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         # Test this script using changes in a fork
-        # repository: 'azure/dotnet-extensions-experimental'
-        repository: 'tratcher/dotnet-extensions-experimental'
+        repository: 'azure/dotnet-extensions-experimental'
         path: azure-extensions
         ref: main
     - name: Checkout dotnet extensions
@@ -59,8 +58,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # Test this script using an issue in the local forked repo
-        # $issue = 'https://api.github.com/repos/azure/dotnet-extensions-experimental/issues/1'
-        $issue = 'https://api.github.com/repos/tratcher/dotnet-extensions-experimental/issues/1'
+        $issue = 'https://api.github.com/repos/azure/dotnet-extensions-experimental/issues/1'
         $sendpr = .\azure-extensions\.github\workflows\ReportDiff.ps1
         echo "sendpr=$sendpr" >> $env:GITHUB_OUTPUT
     - name: GIT commit and push all changed files

--- a/.github/workflows/dotnet-sync.yml
+++ b/.github/workflows/dotnet-sync.yml
@@ -68,7 +68,7 @@ jobs:
       shell: cmd
       working-directory: .\azure-extensions\
       env:
-        CI_COMMIT_MESSAGE: Sync shared code from dotnet/extensions, Fixes #1.
+        CI_COMMIT_MESSAGE: Sync shared code from dotnet/extensions
         CI_COMMIT_AUTHOR: DotNet Sync - Github Actions
       # The prior powershell script created the branch
       run: |

--- a/.github/workflows/dotnet-sync.yml
+++ b/.github/workflows/dotnet-sync.yml
@@ -76,4 +76,3 @@ jobs:
         git config --global user.email "GithubActions@users.noreply.github.com"
         git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
         git push
-        branch: github-action/sync-dotnet-extensions

--- a/.github/workflows/dotnet-sync.yml
+++ b/.github/workflows/dotnet-sync.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   compare_repos:
     # Comment out this line to test the scripts in a fork
-    if: github.repository == 'azure/dotnet-extensions-experimental'
+    # if: github.repository == 'azure/dotnet-extensions-experimental'
     name: Sync shared code between Azure and DotNet
     runs-on: windows-latest
     steps:
@@ -24,7 +24,8 @@ jobs:
       uses: actions/checkout@v3
       with:
         # Test this script using changes in a fork
-        repository: 'azure/dotnet-extensions-experimental'
+        # repository: 'azure/dotnet-extensions-experimental'
+        repository: 'tratcher/dotnet-extensions-experimental'
         path: azure-extensions
         ref: main
     - name: Checkout dotnet extensions
@@ -58,19 +59,21 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # Test this script using an issue in the local forked repo
-        $issue = 'https://api.github.com/repos/azure/dotnet-extensions-experimental/issues/1'
+        # $issue = 'https://api.github.com/repos/azure/dotnet-extensions-experimental/issues/1'
+        $issue = 'https://api.github.com/repos/tratcher/dotnet-extensions-experimental/issues/1'
         $sendpr = .\azure-extensions\.github\workflows\ReportDiff.ps1
         echo "sendpr=$sendpr" >> $env:GITHUB_OUTPUT
-    - name: Send PR
+    - name: GIT commit and push all changed files
       if: steps.check.outputs.sendpr == 'true'
-      # https://github.com/marketplace/actions/create-pull-request
-      uses: dotnet/actions-create-pull-request@v4
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        path: .\azure-extensions
-        commit-message: 'Sync shared code from dotnet/extensions'
-        title: 'Sync shared code from dotnet/extensions'
-        body: 'This PR was automatically generated to sync shared code changes from dotnet/extensions. Fixes #1.'
-        base: main
+      shell: cmd
+      working-directory: .\azure-extensions\
+      env:
+        CI_COMMIT_MESSAGE: Sync shared code from dotnet/extensions, Fixes #1.
+        CI_COMMIT_AUTHOR: DotNet Sync - Github Actions
+      # The prior powershell script created the branch
+      run:
+        git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+        git config --global user.email "GithubActions@users.noreply.github.com"
+        git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
+        git push
         branch: github-action/sync-dotnet-extensions
-        branch-suffix: timestamp

--- a/.github/workflows/dotnet-sync.yml
+++ b/.github/workflows/dotnet-sync.yml
@@ -71,7 +71,7 @@ jobs:
         CI_COMMIT_MESSAGE: Sync shared code from dotnet/extensions, Fixes #1.
         CI_COMMIT_AUTHOR: DotNet Sync - Github Actions
       # The prior powershell script created the branch
-      run:
+      run: |
         git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
         git config --global user.email "GithubActions@users.noreply.github.com"
         git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"

--- a/.github/workflows/dotnet-sync.yml
+++ b/.github/workflows/dotnet-sync.yml
@@ -74,5 +74,6 @@ jobs:
       run: |
         git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
         git config --global user.email "GithubActions@users.noreply.github.com"
+        git config push.autoSetupRemote true
         git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
         git push


### PR DESCRIPTION
The last step of the original action didn't work because the permission for actions to send PRs has been disabled org wide. Instead, we'll just push the branch and someone has to create the PR from that.