### PR TITLE
Update Microsoft.Azure.Cosmos to the latest

### DIFF
--- a/eng/Packages/General.props
+++ b/eng/Packages/General.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="Azure.Core" Version="1.25.0" />
     <PackageVersion Include="Azure.Identity" Version="1.7.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.12.0" />
-    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.28.0-preview"/>
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.35.0"/>
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="4.2.434" />
     <PackageVersion Include="Microsoft.ServiceFabric" Version="[7.2.434, )" />


### PR DESCRIPTION
This addresses https://github.com/advisories/GHSA-5crp-9r3c-p9vr.
```
Newtonsoft.Json prior to version 13.0.1 is vulnerable to Insecure Defaults due to improper handling of expressions with high nesting level that lead to StackOverFlow exception or high CPU and RAM usage. Exploiting this vulnerability results in Denial Of Service (DoS).
```

The old Microsoft.Azure.Cosmos depended on 10.0.2, and that was addressed in https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313.
Related https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3924.