### PR TITLE
Format code coverage results

### DIFF
--- a/eng/scripts/ValidateProjectCoverage.ps1
+++ b/eng/scripts/ValidateProjectCoverage.ps1
@@ -62,7 +62,9 @@ Get-ChildItem -Path src -Include '*.*sproj' -Recurse | ForEach-Object {
     $ProjectToMinCoverageMap[$AssemblyName] = $MinCodeCoverage
 }
 
+$esc = [char]27
 $Errors = New-Object System.Collections.ArrayList
+$Kudos = New-Object System.Collections.ArrayList
 
 Write-Verbose "Collecting projects from code coverage report..."
 $CoberturaReport.coverage.packages.package | ForEach-Object {
@@ -73,8 +75,7 @@ $CoberturaReport.coverage.packages.package | ForEach-Object {
 
     Write-Verbose "Project $Name with line coverage $LineCoverage and branch coverage $BranchCoverage"
 
-    if ($ProjectToMinCoverageMap.ContainsKey($Name))
-    {
+    if ($ProjectToMinCoverageMap.ContainsKey($Name)) {
         if ($ProjectToMinCoverageMap[$Name] -eq 'n/a')
         {
             Write-Host "$Name ...code coverage is not applicable"
@@ -83,27 +84,37 @@ $CoberturaReport.coverage.packages.package | ForEach-Object {
 
         [double]$MinCodeCoverage = $ProjectToMinCoverageMap[$Name]
 
-        if ($MinCodeCoverage -gt $LineCoverage)
-        {
+        # Detect the under-coverage
+        if ($MinCodeCoverage -gt $LineCoverage) {
             $IsFailed = $true
             [void]$Errors.Add(
                 (
                     New-Object PSObject -Property @{
-                        "Project"=$Name;"Coverage Type"="Line";
-                        "Actual"=$LineCoverage;"Expected"=$MinCodeCoverage
+                        "Project"=$Name;"Coverage Type"="Line";"Expected"=$MinCodeCoverage;"Actual"="$esc[1m$esc[0;31m$($LineCoverage)$esc[0m"
                     }
                 )
             )
         }
 
-        if ($MinCodeCoverage -gt $BranchCoverage)
-        {
+        if ($MinCodeCoverage -gt $BranchCoverage) {
             $IsFailed = $true
             [void]$Errors.Add(
                 (
                     New-Object PSObject -Property @{
-                        "Project"=$Name;"Coverage Type"="Branch";
-                        "Actual"=$BranchCoverage;"Expected"=$MinCodeCoverage
+                        "Project"=$Name;"Coverage Type"="Branch";"Expected"=$MinCodeCoverage;"Actual"="$esc[1m$esc[0;31m$($BranchCoverage)$esc[0m"
+                    }
+                )
+            )
+        }
+
+        # Detect the over-coverage
+        [int]$lowestReported = [math]::Min([math]::Truncate($LineCoverage), [math]::Truncate($BranchCoverage));
+        Write-Debug "line: $LineCoverage, branch: $BranchCoverage, min: $lowestReported, threshold: $MinCodeCoverage"
+        if ([int]$MinCodeCoverage -lt $lowestReported) {
+            [void]$Kudos.Add(
+                (
+                    New-Object PSObject -Property @{
+                        "Project"=$Name;"Expected"=$MinCodeCoverage;"Actual"="$esc[1m$esc[0;32m$($lowestReported)$esc[0m";
                     }
                 )
             )
@@ -117,6 +128,18 @@ $CoberturaReport.coverage.packages.package | ForEach-Object {
     }
 }
 
+if ($Kudos.Count -ne 0)
+{
+    Write-Header -message "`r`nGood job! The coverage increased" -isError $false
+    $Kudos | `
+        Sort-Object Project | `
+        Format-Table "Project", `
+                    @{ Name="Expected"; Expression="Expected"; Width=10; Alignment = "Right" }, `
+                    @{ Name="Actual"; Expression="Actual"; Width=10; Alignment = "Right" } `
+                    -AutoSize -Wrap
+    Write-Host "##vso[task.logissue type=warning;]Good job! The coverage increased, please update your projects"
+}
+
 if ($Errors.Count -eq 0)
 {
     Write-Host "`r`nAll good, no issues found."
@@ -124,6 +147,12 @@ if ($Errors.Count -eq 0)
 }
 
 Write-Header -message "`r`n[!!] Found $($Errors.Count) issues!" -isError ($Errors.Count -ne 0)
-$Errors | Sort-Object Project, 'Coverage Type' | Format-Table "Project", @{ Name="Coverage Type"; Expression="Coverage Type"; Width=15 }, @{ Name="Actual"; Expression="Actual"; Width=10 }, @{ Name="Expected"; Expression="Expected"; Width=10 } -AutoSize -Wrap
+$Errors | `
+    Sort-Object Project, 'Coverage Type' | `
+    Format-Table "Project", `
+                @{ Name="Coverage Type"; Expression="Coverage Type"; Width=15 }, `
+                @{ Name="Expected"; Expression="Expected"; Width=10; Alignment = "Right" }, `
+                @{ Name="Actual"; Expression="Actual"; Width=10; Alignment = "Right" } `
+                -AutoSize -Wrap
 exit -1;
 

--- a/eng/scripts/ValidateProjectCoverage.ps1
+++ b/eng/scripts/ValidateProjectCoverage.ps1
@@ -90,7 +90,10 @@ $CoberturaReport.coverage.packages.package | ForEach-Object {
             [void]$Errors.Add(
                 (
                     New-Object PSObject -Property @{
-                        "Project"=$Name;"Coverage Type"="Line";"Expected"=$MinCodeCoverage;"Actual"="$esc[1m$esc[0;31m$($LineCoverage)$esc[0m"
+                        "Project" = $Name;
+                        "Coverage Type" = "Line";
+                        "Expected" = $MinCodeCoverage;
+                        "Actual" = "$esc[1m$esc[0;31m$($LineCoverage)$esc[0m"
                     }
                 )
             )
@@ -101,7 +104,10 @@ $CoberturaReport.coverage.packages.package | ForEach-Object {
             [void]$Errors.Add(
                 (
                     New-Object PSObject -Property @{
-                        "Project"=$Name;"Coverage Type"="Branch";"Expected"=$MinCodeCoverage;"Actual"="$esc[1m$esc[0;31m$($BranchCoverage)$esc[0m"
+                        "Project" = $Name;
+                        "Coverage Type" = "Branch";
+                        "Expected" = $MinCodeCoverage;
+                        "Actual" = "$esc[1m$esc[0;31m$($BranchCoverage)$esc[0m"
                     }
                 )
             )
@@ -114,7 +120,9 @@ $CoberturaReport.coverage.packages.package | ForEach-Object {
             [void]$Kudos.Add(
                 (
                     New-Object PSObject -Property @{
-                        "Project"=$Name;"Expected"=$MinCodeCoverage;"Actual"="$esc[1m$esc[0;32m$($lowestReported)$esc[0m";
+                        "Project" = $Name;
+                        "Expected" = $MinCodeCoverage;
+                        "Actual" = "$esc[1m$esc[0;32m$($lowestReported)$esc[0m";
                     }
                 )
             )
@@ -150,9 +158,9 @@ Write-Header -message "`r`n[!!] Found $($Errors.Count) issues!" -isError ($Error
 $Errors | `
     Sort-Object Project, 'Coverage Type' | `
     Format-Table "Project", `
-                @{ Name="Coverage Type"; Expression="Coverage Type"; Width=15 }, `
                 @{ Name="Expected"; Expression="Expected"; Width=10; Alignment = "Right" }, `
-                @{ Name="Actual"; Expression="Actual"; Width=10; Alignment = "Right" } `
+                @{ Name="Actual"; Expression="Actual"; Width=10; Alignment = "Right" }, `
+                @{ Name="Coverage Type"; Expression="Coverage Type"; Width=10; Alignment = "Center" } `
                 -AutoSize -Wrap
 exit -1;
 

--- a/src/Microsoft.Azure.Extensions.Messaging.StorageQueues/Microsoft.Azure.Extensions.Messaging.StorageQueues.csproj
+++ b/src/Microsoft.Azure.Extensions.Messaging.StorageQueues/Microsoft.Azure.Extensions.Messaging.StorageQueues.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <Stage>dev</Stage>
-    <MinCodeCoverage>0</MinCodeCoverage>
+    <MinCodeCoverage>80</MinCodeCoverage>
     <MinMutationScore>70</MinMutationScore>
   </PropertyGroup>
 

--- a/src/Microsoft.Azure.Extensions.Resilience.FaultInjection/Microsoft.Azure.Extensions.Resilience.FaultInjection.csproj
+++ b/src/Microsoft.Azure.Extensions.Resilience.FaultInjection/Microsoft.Azure.Extensions.Resilience.FaultInjection.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <Stage>dev</Stage>
-    <MinCodeCoverage>84</MinCodeCoverage>
+    <MinCodeCoverage>88</MinCodeCoverage>
     <MinMutationScore>85</MinMutationScore>
   </PropertyGroup>
 


### PR DESCRIPTION
* Display when coverage increases
* Better present failures

![image](https://github.com/Azure/dotnet-extensions-experimental/assets/4403806/d88895c5-32bc-415a-bf7d-84009dc0c62e)
